### PR TITLE
Like, unlike, and view liked products

### DIFF
--- a/bangazonapi/models/customer.py
+++ b/bangazonapi/models/customer.py
@@ -7,6 +7,7 @@ class Customer(models.Model):
     user = models.OneToOneField(User, on_delete=models.DO_NOTHING,)
     phone_number = models.CharField(max_length=15)
     address = models.CharField(max_length=55)
+    likes = models.ManyToManyField("Product", related_name="customer_likes")
 
     @property
     def recommends(self):

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -22,6 +22,12 @@ class ProductSerializer(serializers.ModelSerializer):
                   'average_rating', 'can_be_rated', )
         depth = 1
 
+class LikesSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Customer
+        fields = ['likes']
+        depth = 1
+
 
 class Products(ViewSet):
     """Request handlers for Products in the Bangazon Platform"""
@@ -291,5 +297,34 @@ class Products(ViewSet):
             rec.save()
 
             return Response(None, status=status.HTTP_204_NO_CONTENT)
+
+        return Response(None, status=status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    @action(methods=['post','delete'], detail=True)
+    def like(self, request, pk=None):
+        """Like a product"""
+
+        customer = Customer.objects.get(user=request.auth.user)
+        product = Product.objects.get(pk=pk)
+
+        if request.method == "POST":
+            customer.likes.add(product)
+            return Response(None, status=status.HTTP_204_NO_CONTENT)
+
+        if request.method =="DELETE":
+            customer.likes.remove(product)
+            return Response(None, status=status.HTTP_204_NO_CONTENT)
+
+
+        return Response(None, status=status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    @action(methods=['get'], detail=False)
+    def liked(self, request):
+        """List products a customer has liked"""
+
+        if request.method == "GET":
+            customer = Customer.objects.get(user=request.auth.user)
+            serializer = LikesSerializer(customer, context={'request': request})
+            return Response(serializer.data)
 
         return Response(None, status=status.HTTP_405_METHOD_NOT_ALLOWED)


### PR DESCRIPTION
# Likes

## Changes

- Customers can now like a product
- Customers can now unlike a product
- Customers can now see a list of their liked products

## Requests / Responses


**Request**

GET `/products/liked` Returns a list of products the customer has "liked"


**Response**

HTTP/1.1 201 OK

```json
{
    "likes": [
        {
            "id": 33,
            "deleted": null,
            "name": "Stratus",
            "price": 1199.91,
            "description": "2001 Dodge",
            "quantity": 1,
            "created_date": "2019-04-06",
            "location": "Tianning",
            "image_path": null,
            "customer": 7,
            "category": 2
        }
    ]
}
```

## Testing

Description of how to test code...

- [ ] POST to `products/32/like` returns a 204
- [ ] GET to `products/liked` returns a list of liked products
- [ ] DELETE to `products/32/like` returns a 204
- [ ] GET to `products/liked` returns an empty list


## Related Issues

- Fixes #12 