### PR TITLE
removed 'line_items' from profile/cart to eliminate duplicate data

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -185,7 +185,7 @@ class Profile(ViewSet):
                 cart = {}
                 cart["order"] = OrderSerializer(open_order, many=False, context={
                                                 'request': request}).data
-                cart["order"]["line_items"] = line_items.data
+                # cart["order"]["line_items"] = line_items.data
                 cart["order"]["size"] = len(line_items.data)
 
             except Order.DoesNotExist as ex:


### PR DESCRIPTION
Cart functions as intended

## Changes

- a GET to `/profile/cart` no longer returns 2 identical lists of products in the cart

## Requests / Responses

**Request**

GET `/profile/cart` Returns an object of the customer's cart

**Response**

HTTP/1.1 201 OK

```json
{
    "id": 2,
    "url": "http://localhost:8000/orders/2",
    "created_date": "2019-04-12",
    "payment_type": null,
    "customer": "http://localhost:8000/customers/7",
    "lineitems": [
        {
            "id": 4,
            "product": {
                "id": 52,
                "name": "900",
                "price": 1296.98,
                "number_sold": 0,
                "description": "1987 Saab",
                "quantity": 2,
                "created_date": "2019-03-19",
                "location": "Vratsa",
                "image_path": null,
                "average_rating": 0
            }
        },
        {
            "id": 5,
            "product": {
                "id": 33,
                "name": "Stratus",
                "price": 1199.91,
                "number_sold": 0,
                "description": "2001 Dodge",
                "quantity": 1,
                "created_date": "2019-04-06",
                "location": "Tianning",
                "image_path": null,
                "average_rating": 0
            }
        },
        {
            "id": 6,
            "product": {
                "id": 71,
                "name": "Sebring",
                "price": 1045.66,
                "number_sold": 0,
                "description": "1999 Chrysler",
                "quantity": 4,
                "created_date": "2019-05-18",
                "location": "Namibe",
                "image_path": null,
                "average_rating": 0
            }
        }
    ],
    "size": 3
}
```

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] GET to `/profile/cart`
- [ ] I can only see one list of products ("lineitems") in the response body


## Related Issues

- Fixes #24 