### PR TITLE
user can now only see their own payment types

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -79,12 +79,8 @@ class Payments(ViewSet):
 
     def list(self, request):
         """Handle GET requests to payment type resource"""
-        payment_types = Payment.objects.all()
-
-        customer_id = self.request.query_params.get('customer', None)
-
-        if customer_id is not None:
-            payment_types = payment_types.filter(customer__id=customer_id)
+        customer = Customer.objects.get(user=request.auth.user)
+        payment_types = Payment.objects.filter(customer=customer)
 
         serializer = PaymentSerializer(
             payment_types, many=True, context={'request': request})


### PR DESCRIPTION
# Payment Types

## Changes

-user can now only see their own payment types

## Testing

Description of how to test code...

- [ ] GET to `/paymenttypes`
- [ ] Only payments associate with the user are returned


## Related Issues

- Fixes #18 