### PR TITLE
Adding Products to new/open carts only

### DIFF
--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -104,7 +104,8 @@ class Orders(ViewSet):
         """
         customer = Customer.objects.get(user=request.auth.user)
         order = Order.objects.get(pk=pk, customer=customer)
-        order.payment_type = request.data["payment_type"]
+        payment_type = Payment.objects.get(pk=request.data["payment_type"])
+        order.payment_type = payment_type
         order.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -235,7 +235,7 @@ class Profile(ViewSet):
             """
 
             try:
-                open_order = Order.objects.get(customer=current_user)
+                open_order = Order.objects.get(customer=current_user, payment_type__isnull=True)
                 print(open_order)
             except Order.DoesNotExist as ex:
                 open_order = Order()


### PR DESCRIPTION
Products can no longer be added to closed carts

## Changes

- Added `payment_type__isnull=True` to Order requirement, else creating a new order

## Testing

Description of how to test code...

- [ ] Add an item to the cart
- [ ] Check the current cart to see that it's there
- [ ] send a PUT to the order with a payment method to close the cart
- [ ] Check that the current cart is empty
- [ ] Add a new product to the cart
- [ ] Check to see that the new item is in the current cart

## Related Issues

- Fixes #23 