### PR TITLE
Test - Delete a payment

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -56,6 +56,8 @@ class Payments(ViewSet):
             serializer = PaymentSerializer(
                 payment_type, context={'request': request})
             return Response(serializer.data)
+        except Payment.DoesNotExist as ex:
+            return Response(ex.args[0], status=status.HTTP_404_NOT_FOUND)
         except Exception as ex:
             return HttpResponseServerError(ex)
 

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -40,4 +40,18 @@ class PaymentTests(APITestCase):
         self.assertEqual(json_response["expiration_date"], "2024-12-31")
         self.assertEqual(json_response["create_date"], str(datetime.date.today()))
 
-    # TODO: Delete payment type
+    def test_delete_payment(self):
+        """
+        Ensure we can delete a payment type
+        """
+        # Add a payment to the db
+        self.test_create_payment_type()
+        url = "/paymenttypes/1"
+        
+        # Delete Payment, check status
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Ensure payment does not exist
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
# Test - Deleting a payment type

## Changes

- Added 404 to get method of a single payment (retrieve) if payment does not exist
- Test: Ensure a payment can be successfully deleted

## Testing

Description of how to test code...

- [ ] Run test suite - 8 should pass, 0 should fail


## Related Issues

- Fixes #9 