### PR TITLE
Test - Complete an Order

### DIFF
--- a/tests/order.py
+++ b/tests/order.py
@@ -1,3 +1,6 @@
+from bangazonapi.models.order import Order
+from bangazonapi.models.customer import Customer
+from bangazonapi.models.payment import Payment
 import json
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -79,6 +82,44 @@ class OrderTests(APITestCase):
         self.assertEqual(json_response["size"], 0)
         self.assertEqual(len(json_response["lineitems"]), 0)
 
-    # TODO: Complete order by adding payment type
+
+    def test_complete_order(self):
+        """
+        Ensure we can complete an order by adding a payment type
+        """
+        # Add a payment type to the DB
+        customer = Customer.objects.get(pk=1)
+        payment = Payment()
+        payment.merchant_name = "Amex"
+        payment.account_number = "1234567890"
+        payment.customer = customer
+        payment.expiration_date = "2023-12-12"
+        payment.create_date = "2020-12-12"
+
+        payment.save()
+
+        # Create an order
+        self.test_add_product_to_order()
+        order = Order.objects.get(pk=1)
+        url = "/orders/1"
+
+        # Check that the order is open
+        response = self.client.get(url)
+        json_response = json.loads(response.content)
+        self.assertEqual(json_response["payment_type"], None)
+
+        # Complete the order
+        data = {
+            "payment_type": 1
+        }
+        response = self.client.put(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Check that the order has a payment type
+        response = self.client.get(url)
+        json_response = json.loads(response.content)
+
+        self.assertNotEqual(json_response["payment_type"], None)
+
 
     # TODO: New line item is not added to closed order


### PR DESCRIPTION
# Test - Complete an order by adding a payment type

## Changes

- Added a test that:
  - creates an order
  - verifies there is no payment type
  - adds a payment type
  - verifies there is a payment type (and that the order is therefore complete)

Description of how to test code...

- [ ] Run test suite - 8 passes, 0 fails

## Related Issues

- Fixes #11 