### PR TITLE
Report - Favorited sellers

### DIFF
--- a/bangazonapi/fixtures/customers.json
+++ b/bangazonapi/fixtures/customers.json
@@ -3,7 +3,7 @@
     "model": "bangazonapi.customer",
     "pk": 4,
     "fields": {
-        "user": 5,
+        "user": 4,
         "phone_number": "555-1212",
         "address": "100 Infinity Way"
     }
@@ -12,7 +12,7 @@
     "model": "bangazonapi.customer",
     "pk": 5,
     "fields": {
-        "user": 6,
+        "user": 5,
         "phone_number": "555-1212",
         "address": "100 Endless Way"
     }
@@ -21,7 +21,7 @@
     "model": "bangazonapi.customer",
     "pk": 6,
     "fields": {
-        "user": 7,
+        "user": 6,
         "phone_number": "555-1212",
         "address": "100 Dauntless Way"
     }
@@ -30,7 +30,7 @@
     "model": "bangazonapi.customer",
     "pk": 7,
     "fields": {
-        "user": 8,
+        "user": 7,
         "phone_number": "555-1212",
         "address": "100 Indefatiguable Way"
     }

--- a/bangazonapi/fixtures/tokens.json
+++ b/bangazonapi/fixtures/tokens.json
@@ -3,7 +3,7 @@
     "model": "authtoken.token",
     "pk": "9ba45f09651c5b0c404f37a2d2572c026c146688",
     "fields": {
-        "user": 7,
+        "user": 6,
         "created": "2019-10-10T23:41:08.334Z"
     }
 },
@@ -11,7 +11,7 @@
     "model": "authtoken.token",
     "pk": "9ba45f09651c5b0c404f37a2d2572c026c146690",
     "fields": {
-        "user": 5,
+        "user": 4,
         "created": "2019-10-10T23:41:08.334Z"
     }
 },
@@ -19,7 +19,7 @@
     "model": "authtoken.token",
     "pk": "9ba45f09651c5b0c404f37a2d2572c026c146694",
     "fields": {
-        "user": 6,
+        "user": 5,
         "created": "2019-10-10T23:41:08.334Z"
     }
 },
@@ -27,7 +27,7 @@
     "model": "authtoken.token",
     "pk": "9ba45f09651c5b0c404f37a2d2572c026c14669c",
     "fields": {
-        "user": 8,
+        "user": 7,
         "created": "2019-10-10T23:41:08.334Z"
     }
 }

--- a/bangazonapi/fixtures/users.json
+++ b/bangazonapi/fixtures/users.json
@@ -1,7 +1,7 @@
 [
 {
     "model": "auth.user",
-    "pk": 5,
+    "pk": 4,
     "fields": {
         "password": "pbkdf2_sha256$150000$fHDURJBIASpx$trZS1MWc6YiNe5EYNBap+P+zMAwpNgNbUZH/b9bgvdw=",
         "last_login": null,
@@ -19,7 +19,7 @@
 },
 {
     "model": "auth.user",
-    "pk": 6,
+    "pk": 5,
     "fields": {
         "password": "pbkdf2_sha256$150000$GviXrBarvuwF$gzlskakTbrLRnnJxv2UKsJlvCA2A5u5CjFcrdXjDAVM=",
         "last_login": null,
@@ -37,7 +37,7 @@
 },
 {
     "model": "auth.user",
-    "pk": 7,
+    "pk": 6,
     "fields": {
         "password": "pbkdf2_sha256$150000$fpOjFWJQRWRe$98+6dDrxFfYX191Hlk+lD3fTvmCnDbOQ4Wn4L+pTqTk=",
         "last_login": null,
@@ -55,7 +55,7 @@
 },
 {
     "model": "auth.user",
-    "pk": 8,
+    "pk": 7,
     "fields": {
         "password": "pbkdf2_sha256$150000$HBu8sLcgV3lh$o2p9+aH/F9Dk9tIztT2CJDQs5R1gEt925BoKM/XzNXQ=",
         "last_login": null,

--- a/bangazonreports/templates/customers/favorited_sellers.html
+++ b/bangazonreports/templates/customers/favorited_sellers.html
@@ -1,0 +1,23 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Bangazon Reports</title>
+  </head>
+  <body>
+    <h1>Sellers with Favorites</h1>
+
+    {% for customer in customers %}
+        <h2>{{ customer.name }}</h2>
+        <h3>Favorite sellers</h3>
+        <ol>
+            {% for favorite in customer.favorites %}
+            <li>
+                {{ favorite }}
+            </li>
+            {% endfor %}
+        </ol>
+    {% endfor %}
+  </body>
+</html>

--- a/bangazonreports/templates/orders/completed_orders.html
+++ b/bangazonreports/templates/orders/completed_orders.html
@@ -1,0 +1,17 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Bangazon Reports</title>
+  </head>
+  <body>
+    <h1>Completed Orders</h1>
+
+    {% for order in orders_list %}
+        <h2>Order {{ order.id }} - {{ order.name }}</h2>
+        <p>{{ order.total }}</p>
+        <p>{{ order.payment }}</p>
+    {% endfor %}
+  </body>
+</html>

--- a/bangazonreports/templates/orders/incomplete_orders.html
+++ b/bangazonreports/templates/orders/incomplete_orders.html
@@ -1,0 +1,17 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Bangazon Reports</title>
+  </head>
+  <body>
+    <h1>Incomplete Orders</h1>
+
+    {% for order in orders_list %}
+        <h2>Order {{ order.id }} - {{ order.name }}</h2>
+        <p>{{ order.total }}</p>
+        <p>unpaid</p>
+    {% endfor %}
+  </body>
+</html>

--- a/bangazonreports/urls.py
+++ b/bangazonreports/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
-from .views import expensive_products, completed_orders
+from .views import expensive_products, completed_orders, incomplete_orders
 
 urlpatterns = [
     path('reports/expensiveproducts', expensive_products),
     path('reports/orders/completed', completed_orders),
+    path('reports/orders/incomplete', incomplete_orders),
 ]

--- a/bangazonreports/urls.py
+++ b/bangazonreports/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
-from .views import expensive_products, completed_orders, incomplete_orders
+from .views import expensive_products, completed_orders, incomplete_orders, favorited_sellers
 
 urlpatterns = [
     path('reports/expensiveproducts', expensive_products),
     path('reports/orders/completed', completed_orders),
     path('reports/orders/incomplete', incomplete_orders),
+    path('reports/customers/favorites', favorited_sellers)
 ]

--- a/bangazonreports/urls.py
+++ b/bangazonreports/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
-from .views import expensive_products
+from .views import expensive_products, completed_orders
 
 urlpatterns = [
-    path('reports/expensiveproducts', expensive_products)
+    path('reports/expensiveproducts', expensive_products),
+    path('reports/orders/completed', completed_orders),
 ]

--- a/bangazonreports/views/__init__.py
+++ b/bangazonreports/views/__init__.py
@@ -2,3 +2,4 @@ from .connection import Connection
 from .products.expensive_products import expensive_products
 from .orders.completed_orders import completed_orders
 from .orders.incomplete_orders import incomplete_orders
+from .customers.favorited_sellers import favorited_sellers

--- a/bangazonreports/views/__init__.py
+++ b/bangazonreports/views/__init__.py
@@ -1,2 +1,3 @@
 from .connection import Connection
 from .products.expensive_products import expensive_products
+from .orders.completed_orders import completed_orders

--- a/bangazonreports/views/__init__.py
+++ b/bangazonreports/views/__init__.py
@@ -1,3 +1,4 @@
 from .connection import Connection
 from .products.expensive_products import expensive_products
 from .orders.completed_orders import completed_orders
+from .orders.incomplete_orders import incomplete_orders

--- a/bangazonreports/views/customers/favorited_sellers.py
+++ b/bangazonreports/views/customers/favorited_sellers.py
@@ -1,0 +1,60 @@
+""" Module for generating customers with favorited sellers """
+
+from bangazonapi.models.customer import Customer
+from bangazonapi.models.order import Order
+import sqlite3
+from django.shortcuts import render
+from bangazonreports.views import Connection
+
+
+def favorited_sellers(request):
+    """ Function to build an HTML report of completed orders """
+    if request.method == 'GET':
+        with sqlite3.connect(Connection.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            db_cursor = conn.cursor()
+
+            db_cursor.execute("""
+                SELECT
+                    c.id id,
+                    u.first_name ||' '|| u.last_name name,
+                    seller.first_name || ' ' || seller.last_name seller_name
+                FROM
+                    bangazonapi_customer c
+                JOIN
+                    auth_user u ON c.id = u.id
+                JOIN
+                    bangazonapi_favorite f ON f.customer_id = c.id
+                JOIN
+                    auth_user seller ON seller.id = f.seller_id
+            """)
+
+            dataset = db_cursor.fetchall()
+
+            customers= {}
+
+            for row in dataset:
+                customer = Customer
+                customer.name = row["name"]
+                customer.favorite = row["seller_name"]
+
+                uid = row["id"]
+
+                if uid in customers:
+                    customers[uid]['favorites'].append(customer.favorite)
+                else:
+                    customers[uid] = {}
+                    customers[uid]["id"] = uid
+                    customers[uid]["name"] = customer.name
+                    customers[uid]["favorites"] = [customer.favorite]
+
+            
+
+    list_of_customers = list(customers.values())
+
+    template = 'customers/favorited_sellers.html'
+    context = {
+        'customers': list_of_customers
+    }
+
+    return render(request, template, context)

--- a/bangazonreports/views/orders/completed_orders.py
+++ b/bangazonreports/views/orders/completed_orders.py
@@ -1,0 +1,57 @@
+""" Module for generating completed orders """
+
+from bangazonapi.models.order import Order
+import sqlite3
+from django.shortcuts import render
+from bangazonreports.views import Connection
+
+def completed_orders(request):
+    """ Function to build an HTML report of completed orders """
+    if request.method == 'GET':
+        with sqlite3.connect(Connection.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            db_cursor = conn.cursor()
+
+            db_cursor.execute("""
+                SELECT
+                    o.id id,
+                    u.first_name ||' '|| u.last_name Name,
+                    '$' || SUM(p.price) Total,
+                    pay.merchant_name Payment
+                FROM
+                    bangazonapi_order o
+                JOIN
+                    bangazonapi_orderproduct op ON o.id = op.order_id
+                JOIN
+                    bangazonapi_product p ON p.id = op.product_id
+                JOIN
+                    bangazonapi_customer c ON c.id = o.customer_id
+                JOIN
+                    auth_user u ON c.id = u.id
+                JOIN
+                    bangazonapi_payment pay ON pay.id = o.payment_type_id
+                GROUP BY o.id;
+            """)
+
+            dataset = db_cursor.fetchall()
+
+            orders= {}
+
+            for row in dataset:
+                order = Order()
+                order.id = row["id"]
+                order.name = row["Name"]
+                order.total = row["Total"]
+                order.payment = row["Payment"]
+
+                orders[order.id] = order
+
+    list_of_orders = list(orders.values())
+
+    template = 'orders/completed_orders.html'
+    context = {
+        'orders_list': list_of_orders
+    }
+
+    return render(request, template, context)
+

--- a/bangazonreports/views/orders/incomplete_orders.py
+++ b/bangazonreports/views/orders/incomplete_orders.py
@@ -1,0 +1,55 @@
+""" Module for generating completed orders """
+
+from bangazonapi.models.order import Order
+import sqlite3
+from django.shortcuts import render
+from bangazonreports.views import Connection
+
+def incomplete_orders(request):
+    """ Function to build an HTML report of completed orders """
+    if request.method == 'GET':
+        with sqlite3.connect(Connection.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            db_cursor = conn.cursor()
+
+            db_cursor.execute("""
+                SELECT
+                    o.id id,
+                    u.first_name ||' '|| u.last_name Name,
+                    COALESCE(SUM(p.price), '0') Total
+                FROM
+                    bangazonapi_order o
+                JOIN
+                    bangazonapi_orderproduct op ON o.id = op.order_id
+                JOIN
+                    bangazonapi_product p ON p.id = op.product_id
+                JOIN
+                    bangazonapi_customer c ON c.id = o.customer_id
+                JOIN
+                    auth_user u ON c.id = u.id
+                WHERE
+                    o.payment_type_id IS NULL
+                GROUP BY o.id;
+            """)
+
+            dataset = db_cursor.fetchall()
+
+            orders= {}
+
+            for row in dataset:
+                order = Order()
+                order.id = row["id"]
+                order.name = row["Name"]
+                order.total = row["Total"]
+
+                orders[order.id] = order
+
+    list_of_orders = list(orders.values())
+
+    template = 'orders/incomplete_orders.html'
+    context = {
+        'orders_list': list_of_orders
+    }
+
+    return render(request, template, context)
+


### PR DESCRIPTION
# Report - Customers with favorited sellers

Generates an HTML report of users with a list of their favorited sellers

## Changes

- view that grabs users with favorite sellers along with that list of sellers' names
- template to match

## Testing

Description of how to test code...

- [ ] Run server
- [ ] visit `/reports/customers/favorites` in the browser
- [ ] verify an HTML report of 1 user with 3 favorite sellers by name

## Related Issues

- Fixes #2 